### PR TITLE
[update url]: coursera kaggle url

### DIFF
--- a/contents/4.3.1-courses.md
+++ b/contents/4.3.1-courses.md
@@ -68,7 +68,7 @@ Most courses only teach you how to train and tune your models. This is the first
 
 **10. How to Win a Data Science Competition: Learn from Top Kagglers by Coursera**
 
-[See course materials](https://www.coursera.org/learn/competitive-data-science/home/welcome) (free online course)
+[See course materials](https://www.coursera.org/projects/ml-basics-kaggle-competition) (free online course)
 
 With all the knowledge we’ve learned, it’s time to head over to Kaggle to build some machine learning models to gain experience and win some money. Warning: Kaggle grandmasters might not necessarily be good instructors.
 


### PR DESCRIPTION
Hello Chip Huyen,

I really appreciate and enjoy reading your book, ml-interviews-book. 

I think Coursera has updated their kaggle courses. Therefore, the previous link failed. I update the URL for kaggle course on coursera, Get Familiar with ML basics in a Kaggle Competition. You can consider this change if this is similar to the course you meant in the previous version. 

Best